### PR TITLE
Upgrade nix channel and haskell "network" package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,16 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700538105,
-        "narHash": "sha256-uZhOCmwv8VupEmPZm3erbr9XXmyg7K67Ul3+Rx2XMe0=",
+        "lastModified": 1753802321,
+        "narHash": "sha256-5aNoXJymhDsOD/GB8/o86YYdhWIV8k8EjIEVxPwoUYQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "51a01a7e5515b469886c120e38db325c96694c2f",
+        "rev": "e0edf257cee4b8eac64df41fba8a5f6bda13a225",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "release-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-25.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
     system.url = "github:nix-systems/default";
@@ -25,7 +25,7 @@
           services.redis."redis".enable = true;
         };
         haskellProjects.default = {
-          basePackages = pkgs.haskell.packages.ghc947;
+          basePackages = pkgs.haskell.packages.ghc984;
           autoWire = [ "packages" ];
         };
         packages.default = self'.packages.hedis;

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -81,7 +81,7 @@ library
                     text,
                     deepseq,
                     mtl >= 2,
-                    network >= 2 && < 3.2,
+                    network >= 2 && < 3.3,
                     resource-pool >= 0.2,
                     stm,
                     time,


### PR DESCRIPTION
Test results contain a few failures, but they are an exact match to the same few failures from before the upgrade. Just some tests that never got updated on a previous change. We'll need to fix those at some point.

contributes to https://linear.app/noredink/issue/FXN-4014/upgrade-nixpkgs-ref-in-monorepo